### PR TITLE
Trigger `dp.change` event when changing hours and minutes

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -332,15 +332,25 @@
             },
 
             onChangeHours = function (hours) {
-                $('.timepicker-hour').blur()
-                $('.timepicker-hour').val(hours.toString().padStart(2, '0'))
-                return;
+                $('.timepicker-hour').blur();
+                $('.timepicker-hour').val(hours.toString().padStart(2, '0'));
+
+                const newDate = date.clone().hours(hours);
+
+                if (isValid(newDate, 'h')) {
+                    setValue(newDate);
+                }
             },
 
             onChangeMinutes = function (minutes) {
-                $('.timepicker-minute').blur()
-                $('.timepicker-minute').val(minutes.toString().padStart(2, '0'))
-                return;
+                $('.timepicker-minute').blur();
+                $('.timepicker-minute').val(minutes.toString().padStart(2, '0'));
+
+                const newDate = date.clone().minutes(minutes);
+
+                if (isValid(newDate, 'm')) {
+                    setValue(newDate);
+                }
             },
 
             getToolbar = function () {


### PR DESCRIPTION
# Dependents
- https://github.com/fonixcode/radar/pull/2989

# Notes
- Merging to branch `calendars_not_opening_bug`, because it's the one being referenced by [`radar/admin`](https://github.com/fonixcode/radar/blob/CM-1768-improve-datetime-picker-functionality/admin/Gemfile#L23)

# Issues
- https://fonix.atlassian.net/browse/CM-1768