### PR TITLE
Invert up/down navigation icons for month/year selection

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -206,14 +206,14 @@
                     
                 var newHeadTemplate = $('<div>').addClass('header-calendar')
                         .append($('<div>').addClass('month-header-content')
-                                .append($('<span>').addClass(`${options.icons.up} next`).attr('data-action', 'next'))
+                                .append($('<span>').addClass(`${options.icons.up} previous`).attr('data-action', 'previous'))
                                 .append($('<span>').addClass('picker-switch').attr('data-action', 'pickerSwitchMonth'))
-                                .append($('<span>').addClass(`${options.icons.down} previous`).attr('data-action', 'previous'))
+                                .append($('<span>').addClass(`${options.icons.down} next`).attr('data-action', 'next'))
                                 )
                         .append($('<div>').addClass('year-header-content datepicker-months')
-                                .append($('<span>').addClass(`${options.icons.up} next`).attr('data-action', 'next'))
+                                .append($('<span>').addClass(`${options.icons.up} previous`).attr('data-action', 'previous'))
                                 .append($('<span>').addClass('picker-switch').attr('data-action', 'pickerSwitchYear'))
-                                .append($('<span>').addClass(`${options.icons.down} previous`).attr('data-action', 'previous'))
+                                .append($('<span>').addClass(`${options.icons.down} next`).attr('data-action', 'next'))
                                 )
                 
                 var dayHeadTemplate =  $('<thead>')
@@ -744,12 +744,12 @@
                 if (!hasDate()) {
                     return;
                 }
-                daysViewHeader.eq(0).find('span').eq(0).attr('title', options.tooltips.nextMonth);
+                daysViewHeader.eq(0).find('span').eq(0).attr('title', options.tooltips.prevMonth);
                 daysViewHeader.eq(0).find('span').eq(1).attr('title', options.tooltips.selectMonth);
-                daysViewHeader.eq(0).find('span').eq(2).attr('title', options.tooltips.prevMonth);
-                yearsViewHeader.eq(0).find('span').eq(0).attr('title', options.tooltips.nextYear);
+                daysViewHeader.eq(0).find('span').eq(2).attr('title', options.tooltips.nextMonth);
+                yearsViewHeader.eq(0).find('span').eq(0).attr('title', options.tooltips.prevYear);
                 yearsViewHeader.eq(0).find('span').eq(1).attr('title', options.tooltips.selectYear);
-                yearsViewHeader.eq(0).find('span').eq(2).attr('title', options.tooltips.prevYear);
+                yearsViewHeader.eq(0).find('span').eq(2).attr('title', options.tooltips.nextYear);
 
 
                 daysView.find('.disabled').removeClass('disabled');


### PR DESCRIPTION
# Specs
- **Current Behaviour:** Arrow icon direction for navigating months/years causes confusion.
- **Expected Behaviour:** Down arrows should move forward in time, and up arrows should move backward when selecting month/year.

# Dependents
- https://github.com/fonixcode/radar/pull/2989

# Issues
- https://fonix.atlassian.net/browse/CM-1768

# Notes
- Merging to branch `calendars_not_opening_bug`, because it's the one being referenced by [`radar/admin`](https://github.com/fonixcode/radar/blob/CM-1768-improve-datetime-picker-functionality/admin/Gemfile#L23)

# Assets
## Before the changes
https://github.com/user-attachments/assets/017398cb-bd8f-4fc2-9dad-c30d6605db2d

## After the changes
https://github.com/user-attachments/assets/752e64d0-b357-4a51-896b-e8dfd935086f