### PR TITLE
[CM-1809] Time selection bug in Campaigns & SMS Sender

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -203,7 +203,7 @@
                                 .append($('<span>').addClass(options.icons.next))
                                 )
                             )
-                    
+
                 var newHeadTemplate = $('<div>').addClass('header-calendar')
                         .append($('<div>').addClass('month-header-content')
                                 .append($('<span>').addClass(`${options.icons.up} previous`).attr('data-action', 'previous'))
@@ -215,7 +215,7 @@
                                 .append($('<span>').addClass('picker-switch').attr('data-action', 'pickerSwitchYear'))
                                 .append($('<span>').addClass(`${options.icons.down} next`).attr('data-action', 'next'))
                                 )
-                
+
                 var dayHeadTemplate =  $('<thead>')
                 .append($('<tr>'))
                             ,
@@ -1002,7 +1002,7 @@
                 });
 
                 input.blur();
-                input.removeClass('focus');    
+                input.removeClass('focus');
                 viewDate = date.clone();
 
                 return picker;
@@ -1011,7 +1011,7 @@
             close = function () {
                 $('.timepicker-hour').blur();
                 $('.timepicker-minute').blur();
-                input.blur(); 
+                input.blur();
                 input.removeClass('focus');
                 input.val(date.format(actualFormat));
                 setValue(parseInputDate(input.val().trim()));
@@ -1046,7 +1046,7 @@
                             navFnc = datePickerModes[currentViewMode].navFnc;
                         }else{
                             navFnc = datePickerModes[1].navFnc;
-                        }    
+                        }
                     }
                     viewDate.add(datePickerModes[currentViewMode].navStep, navFnc);
                     fillDate();
@@ -1060,7 +1060,7 @@
                             navFnc = datePickerModes[currentViewMode].navFnc;
                         }else{
                             navFnc = datePickerModes[1].navFnc;
-                        }    
+                        }
                     }
                     viewDate.subtract(datePickerModes[currentViewMode].navStep, navFnc);
                     fillDate();
@@ -1340,7 +1340,7 @@
                 );
             },
 
-            setupInputs = function () {                
+            setupInputs = function () {
                 $(input).parent().find('#hour-input').on('blur', function () {
                     const currentValue = this.value > 23 ? '23' : this.value || '00'
                     const hour = parseInt(currentValue);
@@ -1411,7 +1411,7 @@
                 $(window).on('resize', place);
                 widget.on('click', '[data-action]', doAction); // this handles clicks on the widget
                 if(!hasTime()) widget.on('mousedown', false);
-                if (!options.sideBySide && hasDate() && hasTime()) {                 
+                if (!options.sideBySide && hasDate() && hasTime()) {
                     showFooterTimer();
                 }
                 if (component && component.hasClass('btn')) {
@@ -2546,7 +2546,7 @@
             $(window).on('click', (e) => {
                 if (input.is(e.target)) return;
                 var container = $(".bootstrap-datetimepicker-widget");
-                if (!container.is(e.target) && container.has(e.target).length === 0) 
+                if (!container.is(e.target) && container.has(e.target).length === 0)
                 {
                     // if e.target is not the input and not a child of the input
                     hide();

--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -1341,14 +1341,14 @@
             },
 
             setupInputs = function () {                
-                $('#hour-input').on('blur', function () {
+                $(input).parent().find('#hour-input').on('blur', function () {
                     const currentValue = this.value > 23 ? '23' : this.value || '00'
                     const hour = parseInt(currentValue);
                     $(this).val(currentValue);
                     hours = hour;
                     date.hour(hour);
                 })
-                $('#minute-input').on('blur', function () {
+                $(input).parent().find('#minute-input').on('blur', function () {
                     const currentValue = this.value > 59 ? '59' : this.value || "00"
                     const minute = parseInt(currentValue);
                     $(this).val(currentValue);

--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -332,8 +332,8 @@
             },
 
             onChangeHours = function (hours) {
-                $('.timepicker-hour').blur();
-                $('.timepicker-hour').val(hours.toString().padStart(2, '0'));
+                $(input).parent().find('.timepicker-hour').blur();
+                $(input).parent().find('.timepicker-hour').val(hours.toString().padStart(2, '0'));
 
                 const newDate = date.clone().hours(hours);
 
@@ -343,8 +343,8 @@
             },
 
             onChangeMinutes = function (minutes) {
-                $('.timepicker-minute').blur();
-                $('.timepicker-minute').val(minutes.toString().padStart(2, '0'));
+                $(input).parent().find('.timepicker-minute').blur();
+                $(input).parent().find('.timepicker-minute').val(minutes.toString().padStart(2, '0'));
 
                 const newDate = date.clone().minutes(minutes);
 
@@ -1009,8 +1009,8 @@
             },
 
             close = function () {
-                $('.timepicker-hour').blur();
-                $('.timepicker-minute').blur();
+                $(input).parent().find('.timepicker-hour').blur();
+                $(input).parent().find('.timepicker-minute').blur();
                 input.blur();
                 input.removeClass('focus');
                 input.val(date.format(actualFormat));
@@ -1144,7 +1144,7 @@
                     widget.find('.timepicker-minute').focus();
                 },
                 incrementHours: function () {
-                    $('.timepicker-hour').blur();
+                    $(input).parent().find('.timepicker-hour').blur();
                     hours++;
                     if (hours > 23) {
                         hours = 0;
@@ -1153,7 +1153,7 @@
                 },
 
                 incrementMinutes: function () {
-                    $('.timepicker-minute').blur()
+                    $(input).parent().find('.timepicker-minute').blur()
                     minutes++;
                     if (minutes > 59) {
                         minutes = 0;
@@ -1169,7 +1169,7 @@
                 },
 
                 decrementHours: function () {
-                    $('.timepicker-hour').blur();
+                    $(input).parent().find('.timepicker-hour').blur();
                     hours--;
                     if (hours > 23 || hours < 0) {
                         hours = 0;
@@ -1178,7 +1178,7 @@
                 },
 
                 decrementMinutes: function () {
-                    $('.timepicker-minute').blur();
+                    $(input).parent().find('.timepicker-minute').blur();
                     minutes--;
                     if (minutes > 59 || minutes < 0) {
                         minutes = 0;
@@ -1287,8 +1287,8 @@
                 },
 
                 close: function () {
-                    $('.timepicker-minute').blur()
-                    $('.timepicker-hour').blur()
+                    $(input).parent().find('.timepicker-minute').blur()
+                    $(input).parent().find('.timepicker-hour').blur()
                     date.minute(minutes)
                     date.hour(hours)
                     input.removeClass('focus')


### PR DESCRIPTION
There is an issue when selecting a specific time in both Campaigns and SMS Sender, the system inputs the time above the chosen one instead of the assigned time.

# Issues
- https://fonix.atlassian.net/browse/CM-1809

# Related PRs
- https://github.com/fonixcode/radar/pull/3033

# Assets
## Before fix
https://github.com/user-attachments/assets/340beda4-64f0-40ec-8295-3836a8a79613

## After fix
https://github.com/user-attachments/assets/9f424840-e58d-47e7-855b-2045416a3e23
